### PR TITLE
Keywords and multivalued faceting

### DIFF
--- a/src/main/java/de/mirkosertic/desktopsearch/Backend.java
+++ b/src/main/java/de/mirkosertic/desktopsearch/Backend.java
@@ -30,6 +30,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 @Slf4j
 class Backend implements ConfigurationChangeListener {
@@ -305,7 +306,7 @@ class Backend implements ConfigurationChangeListener {
         luceneIndexHandler.shutdown();
     }
 
-    public QueryResult performQuery(final String aQueryString, final String aBasePath, final Map<String, String> aDrilldownDimensions) {
+    public QueryResult performQuery(final String aQueryString, final String aBasePath, final Map<String, Set<String>> aDrilldownDimensions) {
         return luceneIndexHandler.performQuery(aQueryString, aBasePath, configuration, aDrilldownDimensions);
     }
 

--- a/src/main/java/de/mirkosertic/desktopsearch/FacetSearchUtils.java
+++ b/src/main/java/de/mirkosertic/desktopsearch/FacetSearchUtils.java
@@ -15,7 +15,9 @@
  */
 package de.mirkosertic.desktopsearch;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 final class FacetSearchUtils {
 
@@ -26,8 +28,11 @@ final class FacetSearchUtils {
         return aDimension+"="+aValue;
     }
 
-    public static void addToMap(final String aDimensionCriteria, final Map<String, String> aDrilldownDimensions) {
+    public static void addToMap(final String aDimensionCriteria, final Map<String, Set<String>> aDrilldownDimensions) {
         final var p = aDimensionCriteria.indexOf("=");
-        aDrilldownDimensions.put(aDimensionCriteria.substring(0, p), aDimensionCriteria.substring(p + 1));
+        final var dim = aDimensionCriteria.substring(0, p);
+        final var bag = aDrilldownDimensions.getOrDefault(dim, new HashSet<>());
+        bag.add(aDimensionCriteria.substring(p + 1));
+        aDrilldownDimensions.put(dim, bag);
     }
 }

--- a/src/main/java/de/mirkosertic/desktopsearch/SearchServlet.java
+++ b/src/main/java/de/mirkosertic/desktopsearch/SearchServlet.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 @Slf4j
 public class SearchServlet extends HttpServlet {
@@ -67,7 +68,7 @@ public class SearchServlet extends HttpServlet {
                 log.error("Error encoding query string {}", theQueryString, e);
             }
         }
-        final Map<String, String> theDrilldownDimensions = new HashMap<>();
+        final Map<String, Set<String>> theDrilldownDimensions = new HashMap<>();
 
         final var thePathInfo = aRequest.getPathInfo();
         if (!StringUtils.isEmpty(thePathInfo)) {

--- a/src/main/resources/solrhome/core1/conf/managed-schema
+++ b/src/main/resources/solrhome/core1/conf/managed-schema
@@ -19,6 +19,11 @@
     </analyzer>
   </fieldType>
 
+  <fieldType name="kw" class="solr.TextField" sortMissingLast="true" omitTermFreqAndPositions="true" omitNorms="true">
+    <analyzer>
+      <tokenizer class="solr.PatternTokenizerFactory" pattern="\s*(;|,)\s*"/>
+    </analyzer>
+  </fieldType>
   <field name="_root_" type="string" docValues="false" indexed="true" stored="false"/>
   <field name="_version_" type="long" indexed="true" stored="false"/>
 
@@ -30,5 +35,6 @@
   <field name="lastmodified" type="string" multiValued="false" indexed="false" required="true" stored="true"/>
   <field name="locationid" type="string" multiValued="false" indexed="true" required="true" stored="true"/>
 
+  <field name="attr_keywords" type="kw" multiValued="true" indexed="true" required="false" stored="true"/>
   <dynamicField name="attr_*" type="string" multiValued="true" indexed="true" stored="true"/>
 </schema>


### PR DESCRIPTION
This PR adds keywords facet. Changes summary:
- Solr-side tokenize *keywords* string extracted from Office documents and PDFs using `\s*(;|,)\s*`
- Allow for multivalued facet. Previously, only the last one on the search URL matter.
- Hide active facet options (currently in chips)

I'm not 100% sure it is the way to tokenize keywords as a text field with Solr. It seems better to split it the hard way. But I can't think of any other way but using `update-script.js`. However that one will likely be gone, I presume, given [SOLR-14067](https://issues.apache.org/jira/browse/SOLR-14067).

![image](https://user-images.githubusercontent.com/413384/107323938-c344a480-6a6c-11eb-894a-0db5f620f558.png)

